### PR TITLE
2 Bugfixes, small improvements

### DIFF
--- a/check_borg
+++ b/check_borg
@@ -95,12 +95,12 @@ sec_last="$(borg list --format '{time}{NUL}' "${repo}" | xargs '-0' '-I&' 'date'
 last="$(date --date="@${sec_last}")"
 
 # interpret the amount of fails
-if   [ "${sec_warn}" -gt "${sec_last}" ]; then
-	state=$STATE_WARNING
-	msg="BORG WARN, last backup made on ${last}"
-elif [ "${sec_crit}" -gt "${sec_last}" ]; then
+if [ "${sec_crit}" -gt "${sec_last}" ]; then
 	state=$STATE_CRITICAL
 	msg="BORG CRITICAL, last backup made on ${last}"
+elif [ "${sec_warn}" -gt "${sec_last}" ]; then
+	state=$STATE_WARNING
+	msg="BORG WARN, last backup made on ${last}"
 else
 	state=$STATE_OK
 	msg="BORG OK, last backup made on ${last}"

--- a/check_borg
+++ b/check_borg
@@ -30,6 +30,7 @@ error(){   echo "$*" >&2; exit $STATE_UNKNOWN; }
 crit='7 days ago'
 warn='3 days ago'
 verbose=0
+repo=''
 
 usage(){
 	cat >&2 <<-FIN

--- a/check_borg
+++ b/check_borg
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -o errexit
 set -o nounset
 
@@ -72,11 +72,11 @@ while getopts ":vhR:a:c:w:" opt; do
 done
 
 
-if [[ -z "${COMMAND_BORG}" ]]; then
+if [ -z "${COMMAND_BORG}" ]; then
 	error "No command 'borg' available."
 fi
 
-if [[ -z "${repo}" ]]; then
+if [ -z "${repo}" ]; then
 	error "No repository specified!"
 fi
 verbose "repo ${repo}"

--- a/check_borg
+++ b/check_borg
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -o errexit
+set -o nounset
 
 PROGNAME=$(basename "$0")
 PROGPATH=$(echo "$0" | sed -e 's,[\\/][^\\/][^\\/]*$,,')
@@ -20,8 +22,9 @@ else
 	exit 128
 fi
 
-debug(){   [ "$verbose" -gt 1 ] && echo "$*"; }
-verbose(){ [ "$verbose" -gt 0 ] && echo "$*"; }
+debug(){   ([ "$verbose" -gt 1 ] && echo "$*") || return 0; }
+verbose(){ ([ "$verbose" -gt 0 ] && echo "$*") || return 0; }
+
 error(){   echo "$*" >&2; exit $STATE_UNKNOWN; }
 
 crit='7 days ago'
@@ -29,7 +32,7 @@ warn='3 days ago'
 verbose=0
 
 usage(){
-	cat >&2 <<-FIN 
+	cat >&2 <<-FIN
 	usage: $PROGNAME -R REPO [-w DATE] [-c DATE] [ -h -v ]
 
 	REPO: borg repo-url
@@ -84,7 +87,6 @@ sec_crit="$(date --date="${crit}" '+%s')"
 
 # check warning and critical values
 if check_range "${sec_crit}" 0:"${sec_warn}" ; then
-	# 
 	error "Warning value has to be a more recent timepoint than critical."
 fi
 
@@ -94,7 +96,7 @@ last="$(date --date="@${sec_last}")"
 
 # interpret the amount of fails
 if   [ "${sec_warn}" -gt "${sec_last}" ]; then
-	state=$STATE_WARN
+	state=$STATE_WARNING
 	msg="BORG WARN, last backup made on ${last}"
 elif [ "${sec_crit}" -gt "${sec_last}" ]; then
 	state=$STATE_CRITICAL


### PR DESCRIPTION
Hi,

Thanks for adding a licence. I finally found some time to put together a proper pull-request. I'm not done with my changes, as the date-utility behaves rather differently on FreeBSD and Linux.

But while working with the script I've found two bugs which in combination have severe consequences:
- the status-code for "warning" is `STATE_WARNING` (not `STATE_WARN`), so `STATE_WARN` results in 0, which is interpreted as "OK"
- if checking for warning first, it gets higher precedence over critical, thus critical errors become warnings (which are being interpreted as "OK" due to the first bug)

Additionally, while looking for solutions for the date-parsing-problem, I found some flags to simplify "get unixtime of last backup".

I separated each logical change into its own commit, so feel free to just pick the bits you're interested in (if at all ;)).