### PR TITLE
Borg 1.0/1.1 fallback

### DIFF
--- a/check_borg
+++ b/check_borg
@@ -5,7 +5,7 @@ set -o nounset
 PROGNAME=$(basename "$0")
 PROGPATH=$(echo "$0" | sed -e 's,[\\/][^\\/][^\\/]*$,,')
 REVISION="0.1"
-COMMAND_BORG="$(command -v borg)"
+COMMAND_BORG="$(command -v ${COMMAND_BORG:-borg})"
 
 # source a utils.sh from nagios-plugins
 # if the check is not executed in the normal check-directory,

--- a/check_borg
+++ b/check_borg
@@ -92,8 +92,23 @@ if check_range "${sec_crit}" 0:"${sec_warn}" ; then
 fi
 
 # get unixtime of last backup
-sec_last="$(borg list --format '{time}{NUL}' "${repo}" | xargs '-0' '-I&' 'date' '--date=&' '+%s' | sort | tail -n 1)"
-last="$(date --date="@${sec_last}")"
+# As there are easier and safer ways to get the latest time stamp in the current borg version,
+# use the ugly ones only when neccessary
+case "$(${COMMAND_BORG} --version | cut -d' ' -f2)" in
+	1.0*)
+		# Get the archive names and then get via borg info the date for the latest archive name
+		# We have to split the pipe chains, as we have to catch if borg failed to execute
+		last_archive="$(${COMMAND_BORG} list --short "${repo}" || exit ${STATE_UNKNOWN})"
+		last_archive="$(echo "${last_archive}" | tail -n 1)"
+		last="$(${COMMAND_BORG} info "${repo}"::"${last_archive}" || exit ${STATE_UNKNOWN})"
+		last="$(echo "${last}" | sed -n 's/^Time (start):\s\(.*\)/\1/p')"
+		sec_last="$(date --date="${last}" '+%s')"
+		;;
+	*)
+		last="$(${COMMAND_BORG} list --sort timestamp --last 1 --format '{time}' "${repo}" || exit ${STATE_UNKNOWN})"
+		sec_last="$(date --date="${last}" '+%s')"
+		;;
+esac
 
 # interpret the amount of fails
 if [ "${sec_crit}" -gt "${sec_last}" ]; then


### PR DESCRIPTION
1. Use borg 1.1 list features for easier processing. With --format and
of --last 1 of borg list, it's now possible to let determine borg,
which archive is the current one and it spits out the time directly.

2. Borg 1.0 never supported list --format for archives. It may be the
case, that I developed this plugin in combination with a self-installed
pip beta executable. There is now a fallback introduced, which gets the
time from the latest archive also under borg 1.0. It's ugly but works
and only meant as a fallback.

Fixes #3 