### PR TITLE
Do not "STATE_UNKNOWN" on unfinished backups

### DIFF
--- a/check_borg
+++ b/check_borg
@@ -1,4 +1,5 @@
 #!/bin/sh
+# @see https://github.com/bebehei/nagios-plugin-check_borg
 
 set -o nounset
 
@@ -118,13 +119,31 @@ case "$(${BORG} --version | cut -d' ' -f2)" in
 		;;
 	*)
 		last="$(${BORG} list --sort timestamp --last 1 --format '{time}')"
-		[ "$?" = 0 ] || error "Cannot list repository archives. Repo Locked?"
+		if [ "$?" = 0 ]
+		then
+			if not ps aux | grep 'borg create' >> /dev/null
+			then
+				error "Cannot list repository archives. Repo Locked?"
+			fi
+		fi
 		;;
 esac
 
 if [ -z "${last}" ]; then
-	echo "BORG CRITICAL, no archive in repository"
-	exit "${STATE_CRITICAL}"
+	if ps aux | grep "${BORG}" | grep 'create' | grep "$BORG_REPO" >> /dev/null
+	then
+		# A process most likely on the same repo is running
+	        state="${STATE_OK}"
+		hours=$(ps -xo etime,cmd | grep "${BORG}" | grep -v python | grep "${BORG_REPO}" | sed 's/^[ ]*//g')
+		inhours=$(echo $hours | awk -F- '{ print $1":"$2 }' | awk -F: '{ print ($1 * 24) + $2 }')
+		from=$(date -d "$inhours hours ago" "+%a %Y-%m-%d %H:%M:%S");
+		msg="BORG OK, still running from ${from}"
+		echo "${msg}"
+		exit "${state}"
+	else
+		echo "BORG CRITICAL, no archive in repository"
+		exit "${STATE_CRITICAL}"
+	fi
 fi
 
 sec_last="$(${DATE} --date="${last}" '+%s')"

--- a/check_borg
+++ b/check_borg
@@ -121,7 +121,7 @@ case "$(${BORG} --version | cut -d' ' -f2)" in
 		last="$(${BORG} list --sort timestamp --last 1 --format '{time}')"
 		if [ "$?" = 0 ]
 		then
-			if not ps aux | grep "${BORG}" | grep 'create' | grep "$BORG_REPO" >> /dev/null
+			if ! (ps aux | grep -E "${BORG}.*create.*${BORG_REPO}" >> /dev/null)
 			then
 				error "Cannot list repository archives. Repo Locked?"
 			fi
@@ -129,11 +129,16 @@ case "$(${BORG} --version | cut -d' ' -f2)" in
 		;;
 esac
 
+stillrunning=0
+
 if [ -z "${last}" ]; then
-	if ps aux | grep "${BORG}" | grep 'create' | grep "$BORG_REPO" >> /dev/null
+	if ps aux | grep -E "${BORG}.*create.*${BORG_REPO}" >> /dev/null
 	then
 		# A process most likely on the same repo is running
-		hours=$(ps -xo etime,cmd | grep "${BORG}" | grep 'create' | grep -v 'python' | grep "${BORG_REPO}" | sed 's/^[ ]*//g' | cut -d ' ' -f 1)
+		# grep -v python: there is generally 2 processes related to borg on the host, one including python in its name and that doesn't
+		# sed 's/^[ ]*//g': remove the spaces padded up front for no reason by ps
+		# cut -d ' ' -f 1: and take only the first argument, etime, drop the full command name
+		hours=$(ps -xo etime,cmd | grep -E "${BORG}.*create'.*${BORG_REPO}" | grep -v python | sed 's/^[ ]*//g' | cut -d ' ' -f 1)
 		#echo "$hours  <= hours"
 		inhours=$(echo $hours | awk -F- '{ print $1":"$2 }' | awk -F: '{ print ($1 * 24) + $2 }')
 		#echo "$inhours  <= inhours"
@@ -156,7 +161,7 @@ elif [ "${sec_warn}" -gt "${sec_last}" ]; then
 	msg="BORG WARN, last backup made on ${last}"
 else
 	state="${STATE_OK}"
-	if [ $stillrunning ] ;
+	if [ $stillrunning -eq 1 ] ;
 	then
 		msg="BORG OK, still running from ${last}"
 	else

--- a/check_borg
+++ b/check_borg
@@ -121,7 +121,7 @@ case "$(${BORG} --version | cut -d' ' -f2)" in
 		last="$(${BORG} list --sort timestamp --last 1 --format '{time}')"
 		if [ "$?" = 0 ]
 		then
-			if not ps aux | grep 'borg create' >> /dev/null
+			if not ps aux | grep "${BORG}" | grep 'create' | grep "$BORG_REPO" >> /dev/null
 			then
 				error "Cannot list repository archives. Repo Locked?"
 			fi

--- a/check_borg
+++ b/check_borg
@@ -133,13 +133,12 @@ if [ -z "${last}" ]; then
 	if ps aux | grep "${BORG}" | grep 'create' | grep "$BORG_REPO" >> /dev/null
 	then
 		# A process most likely on the same repo is running
-	        state="${STATE_OK}"
-		hours=$(ps -xo etime,cmd | grep "${BORG}" | grep -v python | grep "${BORG_REPO}" | sed 's/^[ ]*//g')
+		hours=$(ps -xo etime,cmd | grep "${BORG}" | grep 'create' | grep -v 'python' | grep "${BORG_REPO}" | sed 's/^[ ]*//g' | cut -d ' ' -f 1)
+		#echo "$hours  <= hours"
 		inhours=$(echo $hours | awk -F- '{ print $1":"$2 }' | awk -F: '{ print ($1 * 24) + $2 }')
-		from=$(date -d "$inhours hours ago" "+%a %Y-%m-%d %H:%M:%S");
-		msg="BORG OK, still running from ${from}"
-		echo "${msg}"
-		exit "${state}"
+		#echo "$inhours  <= inhours"
+		last=$(${DATE} -d "$inhours hours ago" "+%a %Y-%m-%d %H:%M:%S");
+		stillrunning=1
 	else
 		echo "BORG CRITICAL, no archive in repository"
 		exit "${STATE_CRITICAL}"
@@ -157,7 +156,12 @@ elif [ "${sec_warn}" -gt "${sec_last}" ]; then
 	msg="BORG WARN, last backup made on ${last}"
 else
 	state="${STATE_OK}"
-	msg="BORG OK, last backup made on ${last}"
+	if [ $stillrunning ] ;
+	then
+		msg="BORG OK, still running from ${last}"
+	else
+		msg="BORG OK, last backup made on ${last}"
+	fi
 fi
 
 echo "${msg}"


### PR DESCRIPTION
Hi there,

I've made a hack so that check_borg send "STATE_OK" when the backups aren't finished and there is a process running that have the same BORG_REPO as the one we're looking to check.

It might be a bit overly complicated with the date to convert the ps output, but it works for us.

G