### PR TITLE
Fix prefix deprecation warning notice

### DIFF
--- a/check_borg
+++ b/check_borg
@@ -123,7 +123,7 @@ case "$(${BORG} --version | cut -d' ' -f2)" in
 		last="$(echo "${last}" | sed -n 's/^Time (start):\s\(.*\)/\1/p')"
 		;;
 	*)
-		last="$(${BORG} list --prefix "${prefix}" --sort timestamp --last 1 --format '{time}')"
+		last="$(${BORG} list --glob-archives "${prefix}*" --sort timestamp --last 1 --format '{time}')"
 		[ "$?" = 0 ] || error "Cannot list repository archives. Repo Locked?"
 		;;
 esac


### PR DESCRIPTION
Borg has deprecated the prefix parameter, so when using this check will output:

`Warning: "--prefix" has been deprecated. Use "--glob-archives 'yourprefix*'" (-a) instead.`

